### PR TITLE
fix: Allow multipart jsx node names, data-qa on new line for multiline jsx open tags.

### DIFF
--- a/lib/rules/onClick.js
+++ b/lib/rules/onClick.js
@@ -41,19 +41,21 @@ module.exports = {
                 if (bypass) return;
 
                 context.report({
-                  node,
-                  message: getError(errors.onClick.message, testAttribute),
-                  fix: function fix(fixer) {
-                    const { nanoid } = require('nanoid');
-                    const suggestedId = nanoid();
-                    const start = node.range[0] + node.name.name.length;
-                    const end = start + 1;
+                    node,
+                    message: getError(errors.onClick.message, testAttribute),
+                    fix: function fix(fixer) {
+                        const { nanoid } = require('nanoid');
+                        const suggestedId = nanoid();
+                        const namePositionEnd = node.name.range[1];
+                        const attributeText = `${ testAttribute }="${ suggestedId }"`;
+                        const start = namePositionEnd - 1;
+                        const end = start + 1;
 
-                    return fixer.insertTextAfterRange(
-                      [start, end],
-                      ' ' + testAttribute + '="' + suggestedId + '"'
-                    );
-                  },
+                        return fixer.insertTextAfterRange(
+                            [start, end],
+                            ` ${ attributeText }`
+                        );
+                    },
                 });
             }
         };

--- a/tests/lib/rules/onClick.js
+++ b/tests/lib/rules/onClick.js
@@ -15,11 +15,10 @@ const { onClick } = errors;
 
 const onClickError = getError(onClick.message, defaults.testAttribute);
 
-
 nanoidMock('nanoid', {
-  nanoid: function () {
-    return 'AbYK0YPm2OWYiMaFPKLbp';
-  },
+    nanoid: function () {
+        return 'AbYK0YPm2OWYiMaFPKLbp';
+    },
 });
 
 const id = require('nanoid');
@@ -45,37 +44,43 @@ ruleTester.run('onClick', rule, {
         {
             code: '<div onClick={ this.handleClick } />',
             errors: [onClickError],
-            output: `<div data-test-id="${suggestedId}" onClick={ this.handleClick } />`,
+            output: `<div data-test-id="${ suggestedId }" onClick={ this.handleClick } />`,
         },
         {
             code: '<div onClick={ this.handleClick }>foo</div>',
             errors: [onClickError],
-            output: `<div data-test-id="${suggestedId}" onClick={ this.handleClick }>foo</div>`,
+            output: `<div data-test-id="${ suggestedId }" onClick={ this.handleClick }>foo</div>`,
         },
         {
             code: '<Bar onClick={ this.handleClick } />',
             errors: [onClickError],
-            output: `<Bar data-test-id="${suggestedId}" onClick={ this.handleClick } />`,
+            output: `<Bar data-test-id="${ suggestedId }" onClick={ this.handleClick } />`,
         },
         {
             code: '<Bar onClick={ this.handleClick }>foo</Bar>',
             errors: [onClickError],
-            output: `<Bar data-test-id="${suggestedId}" onClick={ this.handleClick }>foo</Bar>`,
+            output: `<Bar data-test-id="${ suggestedId }" onClick={ this.handleClick }>foo</Bar>`,
         },
         {
             code: '<Bar onClick={ () => handleClick() }>foo</Bar>',
             errors: [onClickError],
-            output: `<Bar data-test-id="${suggestedId}" onClick={ () => handleClick() }>foo</Bar>`,
+            output: `<Bar data-test-id="${ suggestedId }" onClick={ () => handleClick() }>foo</Bar>`,
         },
         {
             code: '<Bar onClick={ () => handleClick() } disabled={ foo }>foo</Bar>',
             errors: [onClickError],
-            output: `<Bar data-test-id="${suggestedId}" onClick={ () => handleClick() } disabled={ foo }>foo</Bar>`,
+            output: `<Bar data-test-id="${ suggestedId }" onClick={ () => handleClick() } disabled={ foo }>foo</Bar>`,
         },
         {
             code: '<Bar onClick={ () => handleClick() } readonly={ foo }>foo</Bar>',
             errors: [onClickError],
-            output: `<Bar data-test-id="${suggestedId}" onClick={ () => handleClick() } readonly={ foo }>foo</Bar>`,
+            output: `<Bar data-test-id="${ suggestedId }" onClick={ () => handleClick() } readonly={ foo }>foo</Bar>`,
+        },
+        {
+            code: '<Foo.Bar onClick={ () => handleClick() } readonly={ foo }>foo</Foo.Bar>',
+            errors: [onClickError],
+            output:
+              `<Foo.Bar data-test-id="${ suggestedId }" onClick={ () => handleClick() } readonly={ foo }>foo</Foo.Bar>`,
         },
     ].map(parserOptionsMapper)
 });


### PR DESCRIPTION
Before this commit, node names with dots in them caused an error in the rule.

A file containing the following was not lintable, and projects that relied on successful linting to build, commit, etc. would fail.
```
<Media.Item onClick={() => {}} />
```

In this change, I'm switching to using `node.name.range` to get the position for inserting the attribute. That method works for both single and multi-identifier jsx elements.

Also, as a convenience, I'm detecting if a jsx element is on 2 lines, and, if so, adding a newline and indentation. The indentation is simplistic: the same column as the tag opener plus 2 spaces.

```
<Thing
  onClick={foo}
/>
// becomes
<Thing
  data-qa="os_1hG-zWpPAKZzA0t34o"
  onClick={foo}
/>
```

Finally, when running `npm run lint` on the repo before committing, there were some lint errors around indentation for this project and preferring template strings over concatenating strings with `+`, so I fixed those.